### PR TITLE
feat: Setup simulator; Wokwi in vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESP32C6 LCD Sample
 
-This project demonstrates how to use an ESP32C6 microcontroller to interface with a LCD display. The project is developed using PlatformIO and Arduino.
+This project demonstrates how to use an ESP32C6 microcontroller to interface with a LCD display. The project is developed using PlatformIO and Arduino. The simulator used is Wokwi.
 
 ## Table of Contents
 - [Introduction](#introduction)
@@ -17,6 +17,7 @@ This project aims to provide a simple and effective way to control a LCD display
 - Interface with LCD display
 - Display text and graphics
 - Easy-to-use API
+- Simulator setup (Wokwi)
 
 ## Hardware Requirements
 - ESP32C6 microcontroller
@@ -25,24 +26,41 @@ This project aims to provide a simple and effective way to control a LCD display
 ## Software Requirements
 - PlatformIO IDE
 - Arduino core 3.0.x for ESP32C6
-    - Arduino is officially not available through platformio. I used a community branch which allows developent for such case. Check `platform` in `platformio.ini`.
-- `tft_eSPI` library
-    - Due to the lack of support of ESP32C6, at this time, I used [Cincinnatu](https://github.com/Cincinnatu)'s branch which has a [PR](https://github.com/Bodmer/TFT_eSPI/pull/3399) to the library, based on [this issue](https://github.com/Bodmer/TFT_eSPI/issues/3255), but not yet merged.
-    - Using it with the same name but pointed to the branch by specifying the url in `platformio.ini`, to avoid pushing a whole library to VC.
-        - Things can change and break something. Best to keep a local copy and it can be placed in `lib`.
+- Wokwi/Wokwi for vscode (Optional)
+- Libraries
+    - `tft_eSPI`
 
 ## Installation
 1. Clone the repository
 2. Open the project in PlatformIO IDE
 3. Install the required libraries
-4. Compile
 
 ## Usage
 1. **Connect the hardware:**
     - Connect the ESP32C6 to the LCD display via SPI according to pinout diagram.
+        - For testing with simulator it's not necessary
 2. **Update config:**
-    - Open `config/tft_config.h` and make changes according to connection made previous step.
-2. **Upload the code:**
+    - Open `config/device/tft_config.h` and make changes according to connection made previous step.
+        - `config/device/tft_config.h` in the case of simulator
+3. **Compile:**
+    - Select env.
+        - Select between `device` and `sim` env from the switcher in vscode status bar
+    - Build using PlatformIO
+4. **Upload the code:**
     - Upload the code to the ESP32C6 using PlatformIO.
-3. **Run the project:**
+    - No action required for simulator.
+5. **Run the project:**
     - Power on the board and the LCD and test should show up on the display.
+    - For simulator, click on diagram.json in vscode. Press play.
+
+## Project specific quarks
+- Arduino core 3.0.x for ESP32C6
+    - Arduino is officially not available through platformio. I used a community branch which allows developent for such case. Check `platform` in `platformio.ini`.
+- `tft_eSPI` Library setup
+    - Due to the lack of support of ESP32C6, at this time, I used [Cincinnatu](https://github.com/Cincinnatu)'s branch which has a [PR](https://github.com/Bodmer/TFT_eSPI/pull/3399) to the library, based on [this issue](https://github.com/Bodmer/TFT_eSPI/issues/3255), but not yet merged.
+    - Using it with the same name but pointed to the branch by specifying the url in `platformio.ini`, to avoid pushing a whole library to VC.
+    - Things can change and break something. Best to keep a local copy and it can be placed in `lib`.
+- Simulator(Wokwi) setup
+    - Wokwi has limited sets of components to choose from. ST7789 chip does not exist. So, as a workaround I used ILI9341 display. Display config is separately placed in `config/device` and `config/sim`.
+    - Wokwi only has [esp32-c6-devkitc-1](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/user_guide.html), which does not have `GPIO14` exposed whereas [esp32-c6-devkitm-1](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitm-1/user_guide.html) does. The Waveshare ESP32C6 board, that I'm using, has integreated 1.47inch display. The display uses `GPIO14` as Chip select pin. So, the simulator version of `tft_eSPI` library configuration uses `GPIO10` and that is what the chip select pin is connected to in the simulator.
+    - Using ILI9341, made the display bigger (2.8inch) in the simulator. At the moment, I did not find any way to limit/reduce it to the size of the Waveshare board display (1.47inch). So, as a result, the simulator shows more in the display than the device itself.

--- a/config/device/tft_config.h
+++ b/config/device/tft_config.h
@@ -7,15 +7,15 @@
 #define TFT_WIDTH 172  // ST7789 172 x 320
 #define TFT_HEIGHT 320 // ST7789 240 x 320
 
-#define TFT_BL 22  // LED back-light control pin
-#define TFT_BACKLIGHT_ON HIGH  // Level to turn ON back-light (HIGH or LOW)
-
 #define TFT_MOSI 6
 #define TFT_MISO 5
 #define TFT_SCLK 7
 #define TFT_CS   14  // Chip select control pin
 #define TFT_DC   15  // Data Command control pin
 #define TFT_RST  21  // Reset pin (could connect to RST pin)
+
+#define TFT_BL 22  // LED back-light control pin
+#define TFT_BACKLIGHT_ON HIGH  // Level to turn ON back-light (HIGH or LOW)
 
 #define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
 #define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters

--- a/config/sim/tft_config.h
+++ b/config/sim/tft_config.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#define USER_SETUP_LOADED //Stops tft_eSPI from loading default user setup that replaces following macros
+
+#define ILI9341_DRIVER  // Full configuration option, define additional parameters below for this display
+
+#define TFT_WIDTH 172  // ST7789 172 x 320
+#define TFT_HEIGHT 320 // ST7789 240 x 320
+
+#define TFT_MOSI 6
+#define TFT_MISO 5
+#define TFT_SCLK 7
+#define TFT_CS   10  // Chip select control pin
+#define TFT_DC   15  // Data Command control pin
+#define TFT_RST  21  // Reset pin (could connect to RST pin)
+
+#define TFT_BL 22  // LED back-light control pin
+#define TFT_BACKLIGHT_ON HIGH  // Level to turn ON back-light (HIGH or LOW)
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+//#define LOAD_FONT8N // Font 8. Alternative to Font 8 above, slightly narrower, so 3 digits fit a 160 pixel TFT
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+#define SMOOTH_FONT
+
+#define SPI_FREQUENCY 80000000

--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,28 @@
+{
+    "version": 1,
+    "author": "Md Feroj Ahmod",
+    "editor": "wokwi",
+    "parts": [
+      {
+        "type": "board-esp32-c6-devkitc-1",
+        "id": "esp",
+        "top": 192,
+        "left": -57.6,
+        "rotate": 90,
+        "attrs": {}
+      },
+      { "type": "wokwi-ili9341", "id": "lcd1", "top": -124, "left": -105.9, "attrs": {} }
+    ],
+    "connections": [
+      [ "esp:TX", "$serialMonitor:RX", "", [] ],
+      [ "esp:RX", "$serialMonitor:TX", "", [] ],
+      [ "lcd1:LED", "esp:22", "green", [ "h-0.01", "v38.4", "h105.62", "v163.2", "h-96.02" ] ],
+      [ "lcd1:MOSI", "esp:6", "green", [ "v86.4", "h38.39" ] ],
+      [ "lcd1:MISO", "esp:5", "green", [ "v67.2", "h19.19" ] ],
+      [ "lcd1:SCK", "esp:7", "green", [ "v76.8", "h19.19" ] ],
+      [ "lcd1:CS", "esp:10", "green", [ "v86.4", "h19.2" ] ],
+      [ "lcd1:D/C", "esp:15", "green", [ "v57.6", "h153.6", "v163.2", "h-96" ] ],
+      [ "lcd1:RST", "esp:21", "green", [ "v19.2", "h182.4", "v220.8", "h-144" ] ]
+    ],
+    "dependencies": {}
+  }

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,14 +8,25 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:esp32-c6-devkitm-1]
+[env]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
 board = esp32-c6-devkitm-1
 framework = arduino
 build_flags =
-	-include "$PROJECT_DIR/config/tft_config.h"
 	-D ARDUINO_USB_CDC_ON_BOOT=1
 	-D ARDUINO_USB_MODE=1
 lib_deps =
 	tft_eSPI=https://github.com/Cincinnatu/TFT_eSPI.git
 monitor_speed = 460800
+
+[env:dev_device]
+build_flags =
+	${env.build_flags}
+	-include "$PROJECT_DIR/config/device/tft_config.h"
+	-D DEV_DEVICE
+
+[env:dev_sim]
+build_flags =
+	${env.build_flags}
+	-include "$PROJECT_DIR/config/sim/tft_config.h"
+	-D DEV_SIM

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = '.pio/build/dev_sim/firmware.bin'
+elf = '.pio/build/dev_sim/firmware.elf'


### PR DESCRIPTION
## Description
Wokwi simulator for vscode has been setup.

### Steps to setup
- Install vscode extension of Wokwi
- Follow Readme for further steps

### Quirks
- Wokwi has limited sets of components to choose from. ST7789 chip does not exist. So, as a workaround I used ILI9341 display. Display config is separately placed in `config/device` and `config/sim`.
    - Wokwi only has [esp32-c6-devkitc-1](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/user_guide.html), which does not have `GPIO14` exposed whereas [esp32-c6-devkitm-1](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitm-1/user_guide.html) does. The Waveshare ESP32C6 board, that I'm using, has integreated 1.47inch display. The display uses `GPIO14` as Chip select pin. So, the simulator version of `tft_eSPI` library configuration uses `GPIO10` and that is what the chip select pin is connected to in the simulator.
    - Using ILI9341, made the display bigger (2.8inch) in the simulator. At the moment, I did not find any way to limit/reduce it to the size of the Waveshare board display (1.47inch). So, as a result, the simulator shows more in the display than the device itself.